### PR TITLE
Improved 'freesasa_pdb_ishydrogen' function

### DIFF
--- a/src/pdb.c
+++ b/src/pdb.c
@@ -149,11 +149,10 @@ freesasa_pdb_get_atom_name(char *name,
     assert(line);
     if (pdb_line_check(line,PDB_ATOM_NAME_STRL+12) == FREESASA_FAIL) {
         name[0] = '\0';
-        printf("Failed : %s\n", line);
         return FREESASA_FAIL;
     }
     strncpy(name,line+12,PDB_ATOM_NAME_STRL);
-    printf("%s\n", name );
+    // printf("%s\n", name );
     name[PDB_ATOM_NAME_STRL] = '\0';
     return FREESASA_SUCCESS;
 }


### PR DESCRIPTION
This function previously identified some non-hydrogen atoms as hydrogens if the second character in the atom name was 'H/D'. Example: CD,CD1,CD2 or OD1, OD2 etc. Due to this the number of non-H atoms being read were incorrect. 

A new line in the function has been added (defined in pdb.c)